### PR TITLE
EUREKA-161 Update cookie header management

### DIFF
--- a/auth-headers-manager/handler.lua
+++ b/auth-headers-manager/handler.lua
@@ -105,6 +105,7 @@ function AuthTokenManager:access(conf)
   if conf.set_okapi_header then
     if accessToken.source == folioAccessTokenCookie and not kong.request.get_header(okapiTokenHeader) then
       kong.log.debug("Setting X-Okapi-Token header from cookie value")
+      kong.service.request.clear_header(authorizationHeader)
       kong.service.request.set_header(okapiTokenHeader, accessToken.token)
     end
   end
@@ -113,6 +114,7 @@ function AuthTokenManager:access(conf)
   if conf.set_authorization_header then
     if accessToken.source == folioAccessTokenCookie and not kong.request.get_header(authorizationHeader) then
       kong.log.debug("Setting Authorization header from cookie value")
+      kong.service.request.clear_header(okapiTokenHeader)
       kong.service.request.set_header(authorizationHeader, "Bearer " .. accessToken.token)
     end
   end

--- a/auth-headers-manager/handler.lua
+++ b/auth-headers-manager/handler.lua
@@ -37,7 +37,7 @@ local function getCookies()
   return cookies
 end
 
-local function getCleanedCookiesValue(cookies)
+local function getCookieHeaderWithoutAccessToken(cookies)
   if cookies == nil then
     return ""
   end
@@ -127,7 +127,7 @@ function AuthTokenManager:access(conf)
   kong.log.debug("is clean access token cookie enabled: ", conf.clean_access_token_cookie)
   if conf.clean_access_token_cookie then
     kong.service.request.clear_header(cookieHeader)
-    local newCookieHeaderValue = getCleanedCookiesValue(cookies)
+    local newCookieHeaderValue = getCookieHeaderWithoutAccessToken(cookies)
     if newCookieHeaderValue ~= "" then
       kong.service.request.set_header(cookieHeader, newCookieHeaderValue)
     end

--- a/auth-headers-manager/schema.lua
+++ b/auth-headers-manager/schema.lua
@@ -18,6 +18,11 @@ return {
           default = false,
           required = false },
         },
+        { clean_access_token_cookie = {
+          type = "boolean",
+          default = false,
+          required = false },
+        },
       },
     } }
   }

--- a/config/auth-headers-manager.yaml
+++ b/config/auth-headers-manager.yaml
@@ -3,5 +3,6 @@ plugins:
   - config:
       set_okapi_header: true
       set_authorization_header: false
+      clean_access_token_cookie: true
     enabled: true
     name: auth-headers-manager


### PR DESCRIPTION
## Purpose

Add a capability for Kong to clean authorization cookies and leave only one authentication header - `x-okapi-token` or `Authorization`

## Approach

- Adjust lua code to remove duplicated access tokens from request

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
