### PR TITLE
FOLIO-4039 Enable Workflow run on release tags

### DIFF
--- a/.github/workflows/do-docker.yml
+++ b/.github/workflows/do-docker.yml
@@ -1,9 +1,11 @@
 name: Docker central workflow
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main, master ]
-    workflow_dispatch:
+    tags:
+      - '[vV][0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   docker:


### PR DESCRIPTION
After successful tests that this new Workflow does operate on mainline branch, i forgot to also enable for push release tags.
