### PR TITLE
EUREKA-601: add param responsible for uploading large files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A docker image for kong.
 ## Environment Variables
 
 
-| Name                                         |       Default value        | Suggested value | Required | Description                                                                                                                          |
-|:---------------------------------------------|:--------------------------:|:---------------:|:--------:|:-------------------------------------------------------------------------------------------------------------------------------------|
-| KONG_NGINX_HTTPS_LARGE_CLIENT_HEADER_BUFFERS |             -              |     4 200k      |   true   | Set buffer size for large headers to embedded nginx. (https)                                                                         |
-| KONG_NGINX_HTTP_LARGE_CLIENT_HEADER_BUFFERS  |             -              |     4 200k      |   true   | Set buffer size for large headers to embedded nginx. (http)                                                                          |
+| Name                                         | Default value | Suggested value | Required | Description                                                                                   |
+|:---------------------------------------------|:-------------:|:---------------:|:--------:|:----------------------------------------------------------------------------------------------|
+| KONG_NGINX_HTTPS_LARGE_CLIENT_HEADER_BUFFERS |       -       |     4 200k      |   true   | Sets buffer size for large headers to embedded nginx. (https)                                 |
+| KONG_NGINX_HTTP_LARGE_CLIENT_HEADER_BUFFERS  |       -       |     4 200k      |   true   | Sets buffer size for large headers to embedded nginx. (http)                                  |
+| KONG_NGINX_HTTP_CLIENT_MAX_BODY_SIZE         |      1m       |      256m       |  false   | Sets the maximum allowed size of the client request body. Required for uploading large files. |


### PR DESCRIPTION

## Purpose

Configuring `KONG_NGINX_HTTP_CLIENT_MAX_BODY_SIZE` is required for large file uploading.
https://folio-org.atlassian.net/browse/EUREKA-601

## Approach

- update README.md

