### PR TITLE
KONG-20: Bump Kong from EOL 3.7 to current 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG KONG_VERSION=3.7.1-ubuntu
-FROM kong:$KONG_VERSION
+ARG KONG_VERSION=3.9.0-ubuntu
+FROM docker.io/library/kong:$KONG_VERSION
 
 ENV KONG_PROXY_ACCESS_LOG="/dev/stdout txns"
 # This effectively means that both proxy access and admin access logs will both be sent to stdout
@@ -13,7 +13,7 @@ ENV DECK_SERVICE_PROTOCOL=http
 USER root
 
 ARG TARGETARCH
-ARG DECK_VERSION=1.27.1
+ARG DECK_VERSION=1.47.0
 ARG DECK_DIRECTORY="/usr/local/bin/deck"
 ARG DECK_ARTIFACT_NAME="deck_${DECK_VERSION}_linux_${TARGETARCH}.tar.gz"
 ARG DECK_DOWNLOAD_URL="https://github.com/kong/deck/releases/download/v${DECK_VERSION}/${DECK_ARTIFACT_NAME}"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 A docker image for kong.
 
+## Version
+
+The major and minor version of folio-kong matches the major and minor version of the kong container it is based on.
+
+The patch version of folio-kong starts at 0 and gets incremented for each release.
+
 ## Environment Variables
 
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/KONG-20

## Purpose
Don't run Kong with EOL version 3.7.

## Approach
Migrate Kong to 3.9.0.
Migrate Kong Deck from 1.27.1 to 1.47.0.

Explain versioning, see https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/373194753/Versioning+approach+for+folio-kong+and+folio-keycloak

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR: https://github.com/Kong/kong/blob/release/3.9.x/CHANGELOG.md#390
