### PR TITLE
KONG-24: Remove HTTP priority header to work around DoS CVE-2025-31650

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Test
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker compose up -d
+      - run: ./test.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM docker.io/library/kong:$KONG_VERSION
 
 # Kong configuration options documentation: https://github.com/Kong/kong/blob/master/kong.conf.default
 
+# Remove priority header to work around DoS CVE-2025-31650: https://folio-org.atlassian.net/browse/KONG-24
+ENV KONG_NGINX_LOCATION_PROXY_SET_HEADER='Priority ""'
+
 ENV KONG_HEADERS="off"
 ENV KONG_PROXY_ACCESS_LOG="/dev/stdout txns"
 # This effectively means that both proxy access and admin access logs will both be sent to stdout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  dbkong:
+    container_name: dbkong
+    image: docker.io/library/postgres:16-alpine
+    environment:
+      - POSTGRES_PASSWORD=postgres
+    healthcheck:
+      test: 'PGPASSWORD=postgres psql -h dbkong -U postgres -c "SELECT 1" || exit 1'
+      interval: 1s
+      retries: 100
+  kong:
+    container_name: kong
+    build: .
+    ports: ["8000-8002:8000-8002"]
+    environment:
+      KONG_DATABASE: postgres
+      KONG_PG_DATABASE: postgres
+      KONG_PG_HOST: dbkong
+      KONG_PG_PORT: 5432
+      KONG_PG_USER: postgres
+      KONG_PG_PASSWORD: postgres
+      KONG_PROXY_LISTEN: "0.0.0.0:8000"
+      KONG_ADMIN_LISTEN: "0.0.0.0:8001"
+      KONG_PLUGINS: bundled
+      ENV: local
+    depends_on:
+      dbkong:
+        condition: service_healthy
+  init-kong:
+    container_name: init-kong
+    image: docker.io/alpine/socat
+    entrypoint:
+      - "/bin/sh"
+      - "-c"
+      - "until wget -qS http://kong:8001; do sleep 1; done; wget -qS -O - --post-data 'name=echo&url=http://echo:8080' http://kong:8001/services ; wget -qS -O - --post-data 'name=echo&paths[]=/' http://kong:8001/services/echo/routes"
+    depends_on:
+      kong:
+        condition: service_healthy
+  echo:
+    container_name: echo
+    image: docker.io/alpine/socat
+    command: |
+      -T .1 tcp-l:8080,reuseaddr,fork,crlf system:"echo 'HTTP/1.0 200 OK'; echo; cat"
+networks:
+  default:
+    name: kongnet

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,39 @@
+#/bin/sh
+
+# prerequisite: Kong has been started this way:
+# docker-compose build
+# docker-compose up
+
+for a in `seq 100`
+do
+  wget --no-verbose -O - localhost:8000 && break
+  sleep 1
+done  
+
+assert () {
+  if echo "$1" | grep -E "^$2" > /dev/null
+  then
+    echo "OK   found: $2"
+  else
+    echo "FAIL not found: $2"
+    exit 1
+  fi
+}
+
+assertNot () {
+  if echo "$1" | grep -E "^$2"
+  then
+    echo "FAIL found: $2"
+    exit 1
+  else
+    echo "OK   not found: $2"
+  fi
+}
+
+OUT=$( wget --no-verbose -O - --header 'Foo: bar' --header 'Priority: u=4, i' --header 'Cookie: folioAccessToken=abc.def.ghi' --header 'Accept: text/plain' localhost:8000 )
+echo "$OUT"
+assert "$OUT" 'Accept: text/plain'
+assert "$OUT" 'X-Okapi-Token: abc.def.ghi'
+assertNot "$OUT" 'Cookie:'
+assertNot "$OUT" 'Priority:'
+


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/KONG-24

## Purpose
When proxying a request remove the HTTP priority header from the request.

This protects the destination module from the denial of service (DoS) vulnerability in tomcat-embed-core, for details see https://folio-org.atlassian.net/browse/FOLIO-4316

## Approach
`KONG_NGINX_LOCATION_PROXY_SET_HEADER='Priority ""'`

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.