### PR TITLE
KONG-31: Upgrade Kong EOL 3.9.0 → 3.9.1, Deck EOL 1.47.0 → 1.49.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG KONG_VERSION=3.9.0-ubuntu
+ARG KONG_VERSION=3.9.1-ubuntu
 FROM docker.io/library/kong:$KONG_VERSION
 
 # Kong configuration options documentation: https://github.com/Kong/kong/blob/master/kong.conf.default
@@ -19,7 +19,7 @@ ENV DECK_SERVICE_PROTOCOL=http
 USER root
 
 ARG TARGETARCH
-ARG DECK_VERSION=1.47.0
+ARG DECK_VERSION=1.49.1
 ARG DECK_DIRECTORY="/usr/local/bin/deck"
 ARG DECK_ARTIFACT_NAME="deck_${DECK_VERSION}_linux_${TARGETARCH}.tar.gz"
 ARG DECK_DOWNLOAD_URL="https://github.com/kong/deck/releases/download/v${DECK_VERSION}/${DECK_ARTIFACT_NAME}"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/KONG-31

## Purpose
Upgrade EOL and vulnerable versions.

See

* https://github.com/Kong/kong/blob/release/3.9.x/CHANGELOG.md#391 This fixes libexpat security vulnerability: CVE-2024-50602 https://github.com/advisories/GHSA-79wf-qgrg-2p6c
* https://github.com/Kong/deck/releases

See "Fast Moving Infrastructure" release policy: https://folio-org.atlassian.net/wiki/spaces/TC/pages/268436139/Sunflower#Sunflower-Fast-MovingInfrastructure

## Approach
Upgrade Kong from EOL 3.9.0 to 3.9.1.

Upgrade Deck from EOL 1.47.0 to 1.49.1.

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.