### PR TITLE
KONG-41: update response headers in global and version configurations

### DIFF
--- a/config/global.yaml
+++ b/config/global.yaml
@@ -3,6 +3,14 @@ plugins:
   - name: response-transformer
     enabled: true
     config:
+      remove:
+        headers:
+          - Cache-Control
+          - Pragma
+          - Expires
       add:
         headers:
+          - "Cache-Control:private, no-cache, no-store, max-age=0"
+          - "Pragma:no-cache"
+          - "Expires:0"
           - "Strict-Transport-Security:max-age=31536000; includeSubDomains; preload"

--- a/config/version.yaml
+++ b/config/version.yaml
@@ -9,7 +9,11 @@ services:
     plugins:
       - config:
           add:
-            headers: []
+            headers:
+              - "Cache-Control:private, no-cache, no-store, max-age=0"
+              - "Pragma:no-cache"
+              - "Expires:0"
+              - "Strict-Transport-Security:max-age=31536000; includeSubDomains; preload"
             json: []
             json_types: []
           append:
@@ -17,7 +21,10 @@ services:
             json: []
             json_types: []
           remove:
-            headers: []
+            headers:
+              - Cache-Control
+              - Pragma
+              - Expires
             json:
               - configuration
               - pids


### PR DESCRIPTION
## Purpose

Enforce cache-control and HSTS security headers on all Kong-proxied responses. Without explicit removal and re-addition, upstream services can leak permissive or inconsistent cache directives to clients. This change ensures responses always carry `Cache-Control: private, no-cache, no-store, max-age=0`, `Pragma: no-cache`, `Expires: 0`, and `Strict-Transport-Security` regardless of what upstream returns.

https://folio-org.atlassian.net/browse/KONG-41

## Approach

- In `config/global.yaml`: added `Cache-Control`, `Pragma`, and `Expires` to the `response-transformer` plugin's `remove.headers` list so upstream values are stripped, then added the controlled values to `add.headers` alongside the existing HSTS header.
- In `config/version.yaml`: mirrored the same pattern on the version service plugin — added `remove.headers` entries for the three cache headers and added all four security headers (`Cache-Control`, `Pragma`, `Expires`, `Strict-Transport-Security`) to `add.headers`.

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.