### PR TITLE
KONG-41: change response header strategy from remove to replace

### DIFF
--- a/config/global.yaml
+++ b/config/global.yaml
@@ -3,11 +3,11 @@ plugins:
   - name: response-transformer
     enabled: true
     config:
-      remove:
+      replace:
         headers:
-          - Cache-Control
-          - Pragma
-          - Expires
+          - "Cache-Control:private, no-cache, no-store, max-age=0"
+          - "Pragma:no-cache"
+          - "Expires:0"
       add:
         headers:
           - "Cache-Control:private, no-cache, no-store, max-age=0"

--- a/config/version.yaml
+++ b/config/version.yaml
@@ -21,10 +21,7 @@ services:
             json: []
             json_types: []
           remove:
-            headers:
-              - Cache-Control
-              - Pragma
-              - Expires
+            headers: []
             json:
               - configuration
               - pids
@@ -36,7 +33,10 @@ services:
           rename:
             headers: []
           replace:
-            headers: []
+            headers:
+              - "Cache-Control:private, no-cache, no-store, max-age=0"
+              - "Pragma:no-cache"
+              - "Expires:0"
             json: []
             json_types: []
         enabled: true


### PR DESCRIPTION
## Purpose

Switches the response-transformer plugin strategy for cache-control headers (`Cache-Control`, `Pragma`, `Expires`) from `remove` to `replace` in both the global and version-specific Kong configurations.

Previously, headers were removed and then re-added via the `add` action. Using `replace` is more precise: it sets the header value directly if the header is present, avoiding potential duplication or ordering issues from the two-step remove+add approach.

https://folio-org.atlassian.net/browse/KONG-41

## Approach

- In `config/global.yaml`: replaced the `remove` action entries with a `replace` action that sets explicit values for `Cache-Control`, `Pragma`, and `Expires`.
- In `config/version.yaml`: moved the three cache-control headers from the `remove` list to the `replace` list with their target values, leaving `remove.headers` empty.

## TODOS and Open Questions

- [ ] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.