### PR TITLE
KONG-52: Upgrade FOLIO Kong base image to upstream Kong 3.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG KONG_VERSION=3.9.1-ubuntu
+ARG KONG_VERSION=3.9.3-ubuntu
 FROM docker.io/library/kong:$KONG_VERSION
 
 # Kong configuration options documentation: https://github.com/Kong/kong/blob/master/kong.conf.default
@@ -33,7 +33,7 @@ RUN mkdir "$DECK_DIRECTORY" \
     && curl -sL "$DECK_DOWNLOAD_URL" -o "$DECK_DIRECTORY/$DECK_ARTIFACT_NAME" \
     && tar -xf "$DECK_DIRECTORY/$DECK_ARTIFACT_NAME" -C "$DECK_DIRECTORY" \
     && rm -f "$DECK_DIRECTORY/$DECK_ARTIFACT_NAME"
-ENV PATH = "$PATH:$DECK_DIRECTORY"
+ENV PATH="$PATH:$DECK_DIRECTORY"
 COPY config /opt/kong/config
 COPY entrypoint.sh /entrypoint.sh
 

--- a/config/version.yaml
+++ b/config/version.yaml
@@ -5,7 +5,7 @@ services:
     host: 127.0.0.1
     name: version
     tags: [ "automation" ]
-    path: /
+    path: /version
     plugins:
       - config:
           add:
@@ -14,31 +14,13 @@ services:
               - "Pragma:no-cache"
               - "Expires:0"
               - "Strict-Transport-Security:max-age=31536000; includeSubDomains; preload"
-            json: []
-            json_types: []
-          append:
-            headers: []
-            json: []
-            json_types: []
           remove:
-            headers: []
-            json:
-              - configuration
-              - pids
-              - timers
-              - node_id
-              - hostname
-              - plugins
-              - tagline
-          rename:
             headers: []
           replace:
             headers:
               - "Cache-Control:private, no-cache, no-store, max-age=0"
               - "Pragma:no-cache"
               - "Expires:0"
-            json: []
-            json_types: []
         enabled: true
         name: response-transformer
         protocols:

--- a/config/version.yaml
+++ b/config/version.yaml
@@ -5,7 +5,7 @@ services:
     host: 127.0.0.1
     name: version
     tags: [ "automation" ]
-    path: /version
+    path: /
     plugins:
       - config:
           add:
@@ -14,13 +14,31 @@ services:
               - "Pragma:no-cache"
               - "Expires:0"
               - "Strict-Transport-Security:max-age=31536000; includeSubDomains; preload"
+            json: []
+            json_types: []
+          append:
+            headers: []
+            json: []
+            json_types: []
           remove:
+            headers: []
+            json:
+              - configuration
+              - pids
+              - timers
+              - node_id
+              - hostname
+              - plugins
+              - tagline
+          rename:
             headers: []
           replace:
             headers:
               - "Cache-Control:private, no-cache, no-store, max-age=0"
               - "Pragma:no-cache"
               - "Expires:0"
+            json: []
+            json_types: []
         enabled: true
         name: response-transformer
         protocols:


### PR DESCRIPTION
### Purpose

The `folio-kong` image currently uses Kong Gateway `3.9.1-ubuntu` as its base. This upgrade moves to `3.9.3-ubuntu` to incorporate upstream security patches — notably nginx CVEs addressed in 3.9.2 and [CVE-2026-49975](https://www.cve.org/CVERecord?id=CVE-2026-49975) addressed in 3.9.3.

US: [KONG-52](https://folio-org.atlassian.net/browse/KONG-52)

### Approach

The change is confined to the `Dockerfile`. The base image `ARG` is bumped from `3.9.1-ubuntu` to `3.9.3-ubuntu`, and a pre-existing `ENV PATH` syntax defect (spaces around `=`) is corrected at the same time. All FOLIO-specific configuration, the `auth-headers-manager` plugin, the CVE-2025-31650 `Priority` header mitigation, and the `deck` installation are left untouched.

- Changed `ARG KONG_VERSION` from `3.9.1-ubuntu` to `3.9.3-ubuntu` to pull the latest 3.9.x Kong Gateway base image, picking up upstream security fixes from 3.9.2 and 3.9.3.
- Fixed `ENV PATH` assignment syntax by removing spaces around `=` (`ENV PATH = "..."` →  `ENV PATH="..."`). The prior form treated `PATH ` (with a trailing space) as the variable name,  so `deck` was not reachable on the shell `PATH` at runtime.

### Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [x] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.